### PR TITLE
Add get index and update types

### DIFF
--- a/src/LazySequences.jl
+++ b/src/LazySequences.jl
@@ -15,7 +15,7 @@ seq(::Nothing) = nothing
 # Cons
 # ----
 
-type Cons <: Seqable
+immutable Cons <: Seqable
     first
 
     # This must be something with a seq function.
@@ -38,7 +38,7 @@ cons(first, rest) = Cons(first, rest)
 # Common operations
 # -----------------
 
-immutable Cat <: Seqable
+type Cat <: Seqable
     a::Seqable
     b # Something with a seq function.
 end
@@ -46,6 +46,13 @@ end
 
 first(s::Cat) = first(s.a)
 
+function getindex(s::Cat, n::Int64)
+    sequence = Any[]
+    for i in take(n, s)
+        push!(sequence, i)
+    end
+    sequence[end]
+end
 
 function rest(s::Cat)
     a = rest(s.a)
@@ -202,4 +209,3 @@ end
 
 
 end # end module
-

--- a/src/LazySequences.jl
+++ b/src/LazySequences.jl
@@ -15,7 +15,7 @@ seq(::Nothing) = nothing
 # Cons
 # ----
 
-immutable Cons <: Seqable
+type Cons <: Seqable
     first
 
     # This must be something with a seq function.
@@ -46,14 +46,6 @@ end
 
 first(s::Cat) = first(s.a)
 
-function getindex(s::Cat, n::Int64)
-    sequence = Any[]
-    for i in take(n, s)
-        push!(sequence, i)
-    end
-    sequence[end]
-end
-
 function rest(s::Cat)
     a = rest(s.a)
     if a === nothing
@@ -63,6 +55,13 @@ function rest(s::Cat)
     end
 end
 
+function getindex(s::Cat, n::Int64)
+    sequence = Any[]
+    for i in take(n, s)
+        push!(sequence, i)
+    end
+    sequence[end]
+end
 
 cat(a) = seq(a)
 cat(a, b) = Cat(seq(a), b)

--- a/test/lazy_test.jl
+++ b/test/lazy_test.jl
@@ -1,0 +1,6 @@
+using LazySequences
+
+# Test getindex implementation
+fibs = cat([0, 1], @lazyseq map(+, rest(fibs), fibs))
+@assert fibs[1] == 0
+@assert fibs[2] == 1

--- a/test/lazy_test.jl
+++ b/test/lazy_test.jl
@@ -17,3 +17,5 @@ ct = cat([1], [42])
 fibs = cat([0, 1], @lazyseq map(+, rest(fibs), fibs))
 @assert fibs[1] == 0
 @assert fibs[2] == 1
+@assert fibs[3] == 1
+@assert fibs[4] == 2

--- a/test/lazy_test.jl
+++ b/test/lazy_test.jl
@@ -1,9 +1,17 @@
 using LazySequences
 
 # Cons
-c = cons(1, [0])
+c = cons(1, [42])
+# Test first(s::Cons)
 @assert first(c) == 1
-@assert first(rest(c)) == 0
+# Test rest(s::Cons)
+@assert first(rest(c)) == 42
+
+ct = cat([1], [42])
+# Test first(s::Cat)
+@assert first(ct) == 1
+# Test rest(s::Cat)
+
 
 # Test getindex implementation
 fibs = cat([0, 1], @lazyseq map(+, rest(fibs), fibs))

--- a/test/lazy_test.jl
+++ b/test/lazy_test.jl
@@ -1,5 +1,10 @@
 using LazySequences
 
+# Cons
+c = cons(1, [0])
+@assert first(c) == 1
+@assert first(rest(c)) == 0
+
 # Test getindex implementation
 fibs = cat([0, 1], @lazyseq map(+, rest(fibs), fibs))
 @assert fibs[1] == 0


### PR DESCRIPTION
Simple workaround to make the example code work with Julia 0.2.

This also adds in a getindex(s::Cat, n::Int) which allows for direct access to a lazyseq, eg:

``` julia
fibs[5] #=> 21
```

I would like to add more tests to this library as I figure out exactly how to do that.
